### PR TITLE
sctools listen: print the translated HID token

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -388,7 +388,8 @@ static void xlate_keys(int count)
 
 	for (i = 0; i < count; i++) {
 		/* A key event */
-		if ((buf[i] == '-' || buf[i] == '+') && i + 3 < count) {
+		if ((buf[i] == 'd' || buf[i] == 'u' || buf[i] == '-' ||
+		     buf[i] == '+') && i + 3 < count) {
 			c = buf[i + 3];
 			buf[i + 3] = 0;
 			key = strtol((const char *)(buf + i + 1),  NULL, 16);


### PR DESCRIPTION
The Soarer's converter has the capability to translate the
key code. So it is useful to print also the translated HID token.
With this patch after the uXX e dXX code, it is showed the HID token.

In the example below, the coverter doesn't traslate the ENTER key, but
translates the ESC key in NUM_LOCK.

Before:
[...]
rF0 r5A -28 (ENTER) u28
r76 +29 (ESC) d53 wED rFA w02 rFA
rF0 r76 -29 (ESC) u53
[...]

After:
[...]
rF0 r5A -28 (ENTER) u28 (ENTER)
r76 +29 (ESC) d53 (NUM_LOCK) wED rFA w02 rFA
rF0 r76 -29 (ESC) u53 (NUM_LOCK)
[...]